### PR TITLE
Always show parse errors

### DIFF
--- a/requirements.lwr
+++ b/requirements.lwr
@@ -38,6 +38,7 @@
             1.g.g.b. The command must output a warning with any requirements that use unknown flags that do not begin with a dash (-).
             1.g.g.c. The command must output a warning with any requirements that are incomplete.
             1.g.g.d. The command must output an error with any requirements that cannot be parsed.
+                1.g.g.d.a. The command MUST output parse errors even for requirements that do not fall within the super ID supplied to the command.
             1.g.g.e. The command must output an error with any requirement immediately following a gap.
             1.g.g.f. The command must output an error with any requirement with an ID that is duplicated.
             1.g.g.g. The command must output an error with any requirement that is out of order.

--- a/src/Analyzer.php
+++ b/src/Analyzer.php
@@ -21,7 +21,7 @@ class Analyzer
         $last_was_failed_parse = false;
 
         $requirements = $super_id 
-            ? $this->specification->getByIdWithChildren($super_id)
+            ? $this->specification->getByIdWithChildren($super_id, true)
             : $this->specification->getAll();
 
         $analysis->requirements = array_map(function ($requirement) use (&$last_id, &$last_was_failed_parse, $analysis, $super_id) {

--- a/src/Analyzer.php
+++ b/src/Analyzer.php
@@ -31,6 +31,7 @@ class Analyzer
                 if ($requirement->hasParseError()) {
                     $analysis->parseFailureCount++;
                     $requirement_analysis->has_error = true;
+                    $requirement_analysis->has_parse_error = true;
                     $requirement_analysis->is_inactive = true;
                     $requirement_analysis->notes[] = "Cannot Parse Requirement";
                 } elseif ($requirement->hasFlag('X')) {

--- a/src/Command.php
+++ b/src/Command.php
@@ -36,7 +36,7 @@ class Command extends \Illuminate\Console\Command
 
         $this->info('Results:');
 
-        app(Reporter::class, [$analysis, $this->getVerbosity(), $id])->report($this);
+        app(Reporter::class, [$analysis, $this->getVerbosity()])->report($this);
     }
 
     private function getVerbosity() : int

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -38,6 +38,9 @@ class Reporter
                     if ($requirement_analysis->is_incomplete) {
                         return true;
                     }
+                    if ($requirement_analysis->has_parse_error) {
+                        return true;
+                    }
                     return false;
                 }
                 if ($this->verbosity === static::VERBOSE) {

--- a/src/RequirementAnalysis.php
+++ b/src/RequirementAnalysis.php
@@ -8,6 +8,7 @@ class RequirementAnalysis
     public $line;
     public $is_inactive;
     public $has_error;
+    public $has_parse_error;
     public $is_obsolete;
     public $is_incomplete;
     public $has_warning;
@@ -16,13 +17,14 @@ class RequirementAnalysis
 
     public function __construct(array $fields)
     {
-        $this->line          = $fields['line'] ?? '';
-        $this->is_inactive   = $fields['is_inactive'] ?? false;
-        $this->has_error     = $fields['has_error'] ?? false;
-        $this->is_obsolete   = $fields['is_obsolete'] ?? false;
-        $this->is_incomplete = $fields['is_incomplete'] ?? false;
-        $this->has_warning   = $fields['has_warning'] ?? false;
-        $this->is_pending    = $fields['is_pending'] ?? false;
-        $this->notes         = $fields['notes'] ?? [];
+        $this->line            = $fields['line'] ?? '';
+        $this->is_inactive     = $fields['is_inactive'] ?? false;
+        $this->has_error       = $fields['has_error'] ?? false;
+        $this->has_parse_error = $fields['has_parse_error'] ?? false;
+        $this->is_obsolete     = $fields['is_obsolete'] ?? false;
+        $this->is_incomplete   = $fields['is_incomplete'] ?? false;
+        $this->has_warning     = $fields['has_warning'] ?? false;
+        $this->is_pending      = $fields['is_pending'] ?? false;
+        $this->notes           = $fields['notes'] ?? [];
     }
 }

--- a/src/Specification.php
+++ b/src/Specification.php
@@ -28,13 +28,16 @@ class Specification
         return $this->lines;
     }
 
-    public function getByIdWithChildren(string $id) : array
+    public function getByIdWithChildren(string $id, bool $include_all_parse_errors = false) : array
     {
-        $requirements = array_values(array_filter($this->lines, function ($line) use ($id) {
+        $requirements = array_values(array_filter($this->lines, function ($line) use ($id, $include_all_parse_errors) {
             if (!$line instanceof Requirement) {
                 return true;
             }
             if (substr($line->id, 0, strlen($id)) === $id) {
+                return true;
+            }
+            if ($include_all_parse_errors && $line->hasParseError()) {
                 return true;
             }
             return false;

--- a/tests/AnalyzerTest.php
+++ b/tests/AnalyzerTest.php
@@ -277,6 +277,68 @@ class AnalyzerTest extends TestCase
      * @LWR 1.g.f.c. In double-verbose mode and above the command must output 
      * all requirements.
      *
+     * @LWR 1.g.g.d. The command must output an error with any requirements 
+     * that cannot be parsed.
+     *
+     * @LWR 1.g.g.d.a. The command MUST output parse errors even for 
+     * requirements that do not fall within the super ID supplied to the 
+     * command.
+     * 
+     * @LWR 1.g.j. The command should output the number of errors due to 
+     * failure to parse.
+     */
+    public function testReportBadParseWrongSuperId()
+    {
+        $requirements = [
+            new Requirement('1. Must love dogs'),
+            new Requirement('1.a Must love dogs'),
+            new Requirement('1.b. Must love dogs'),
+        ];
+
+        $spec = new Specification($requirements);
+
+        $id = 2;
+
+        $analyzer = new Analyzer($spec, $this->buildGrepper([]));
+        $analysis = $analyzer->getAnalysis($id);
+
+        $this->assertEquals(0, $analysis->progress);
+        $this->assertEquals(1, $analysis->active);
+        $this->assertEquals(0, $analysis->addressed);
+        $this->assertEquals(0, $analysis->obsolete);
+        $this->assertEquals(1, $analysis->parseFailureCount);
+
+        $this->assertEquals(
+            new RequirementAnalysis([
+                'line'        => '1.a Must love dogs',
+                'has_error'   => true,
+                'is_inactive' => true,
+                'notes'       => ['Cannot Parse Requirement'],
+            ]),
+            $analysis->requirements[0]
+        );
+        $this->assertCount(1, $analysis->requirements);
+    }
+
+    /**
+     * @LWR 1.g. The command must output a description of the code's 
+     * references to the requirements.
+     *
+     * @LWR 1.g.b. The command must output progress as the percentage of 
+     * requirements that have been addressed.
+     * 
+     * @LWR 1.g.c. The command must output the number of requirements that are 
+     * not obsolete.
+     *
+     * @LWR 1.g.d. The command must output the number of requirements that 
+     * have been addressed and are not obsolete.
+     *
+     * @LWR 1.g.e. The command should output the number of requirements that 
+     * are obsolete.
+     *
+     * @LWR 1.g.f.c. In double-verbose mode and above the command must output 
+     * all requirements.
+     *
      * @LWR 1.g.g.h. The command must output a flag with any requirements that 
      * are not addressed.
      *

--- a/tests/AnalyzerTest.php
+++ b/tests/AnalyzerTest.php
@@ -242,10 +242,11 @@ class AnalyzerTest extends TestCase
         );
         $this->assertEquals(
             new RequirementAnalysis([
-                'line'        => '1.a Must love dogs',
-                'has_error'   => true,
-                'is_inactive' => true,
-                'notes'       => ['Cannot Parse Requirement'],
+                'line'            => '1.a Must love dogs',
+                'has_error'       => true,
+                'has_parse_error' => true,
+                'is_inactive'     => true,
+                'notes'           => ['Cannot Parse Requirement'],
             ]),
             $analysis->requirements[1]
         );

--- a/tests/AnalyzerTest.php
+++ b/tests/AnalyzerTest.php
@@ -310,10 +310,11 @@ class AnalyzerTest extends TestCase
 
         $this->assertEquals(
             new RequirementAnalysis([
-                'line'        => '1.a Must love dogs',
-                'has_error'   => true,
-                'is_inactive' => true,
-                'notes'       => ['Cannot Parse Requirement'],
+                'line'            => '1.a Must love dogs',
+                'has_error'       => true,
+                'has_parse_error' => true,
+                'is_inactive'     => true,
+                'notes'           => ['Cannot Parse Requirement'],
             ]),
             $analysis->requirements[0]
         );

--- a/tests/AnalyzerTest.php
+++ b/tests/AnalyzerTest.php
@@ -303,7 +303,7 @@ class AnalyzerTest extends TestCase
         $analysis = $analyzer->getAnalysis($id);
 
         $this->assertEquals(0, $analysis->progress);
-        $this->assertEquals(1, $analysis->active);
+        $this->assertEquals(0, $analysis->active);
         $this->assertEquals(0, $analysis->addressed);
         $this->assertEquals(0, $analysis->obsolete);
         $this->assertEquals(1, $analysis->parseFailureCount);

--- a/tests/ReporterTest.php
+++ b/tests/ReporterTest.php
@@ -58,8 +58,12 @@ class ReporterTest extends TestCase
      * 
      * @LWR 1.g.m. The command should output the number of errors due to 
      * requirements being out of order.
+     *
+     * @LWR 1.g.g.d.a. The command MUST output parse errors even for 
+     * requirements that do not fall within the super ID supplied to the 
+     * command.
      */
-    public function testReportAFewThings()
+    public function testReportAFewThings_VeryVerbose()
     {
         $analysis = new Analysis();
         $analysis->progress = 60;
@@ -93,7 +97,14 @@ class ReporterTest extends TestCase
                 'is_pending' => true,
                 'has_warning' => true,
                 'notes' => ['Well-written requirements use RFC 2119 keywords such as MUST, SHOULD, and MAY'],
-            ])
+            ]),
+
+            new RequirementAnalysis([]),
+
+            new RequirementAnalysis([
+                'line'            => 'PARSE ERROR',
+                'has_parse_error' => true,
+            ]),
         ];
         $analysis->rfc2119WarningCount = 1;
         $analysis->customFlagWarningCount = 2;
@@ -142,6 +153,8 @@ class ReporterTest extends TestCase
                     ['', '3. The gods must be crazy'],
                     ['-', '  3.a. Funny you should ask'],
                     ['-?', "  3.b. It shood happen to you\nWell-written requirements use RFC 2119 keywords such as MUST, SHOULD, and MAY"],
+                    ['', ''],
+                    ['', 'PARSE ERROR'],
                 ]
             )
             ->once();
@@ -206,14 +219,15 @@ class ReporterTest extends TestCase
         $analysis->obsolete = 8;
         $analysis->requirements = [
             new RequirementAnalysis([
-                'line' => 'Wooo',
-                'is_inactive' => true,
-                'has_error' => true,
-                'is_obsolete' => true,
-                'is_incomplete' => true,
-                'has_warning' => true,
-                'is_pending' => true,
-                'notes' => ['We'],
+                'line'            => 'Wooo',
+                'is_inactive'     => true,
+                'has_error'       => true,
+                'is_obsolete'     => true,
+                'is_incomplete'   => true,
+                'has_warning'     => true,
+                'is_pending'      => true,
+                'has_parse_error' => true,
+                'notes'           => ['We'],
             ]),
         ];
         $analysis->duplicateIdErrorCount = 5;
@@ -291,8 +305,12 @@ class ReporterTest extends TestCase
      * failure to parse.
      *
      * @LWR 1.g.k. The command should output the number of errors due to gaps.
+     *
+     * @LWR 1.g.g.d.a. The command MUST output parse errors even for 
+     * requirements that do not fall within the super ID supplied to the 
+     * command.
      */
-    public function testReportFewestThings()
+    public function testReportFewestThings_Normal()
     {
         $analysis = new Analysis();
         $analysis->progress = 60;
@@ -326,7 +344,14 @@ class ReporterTest extends TestCase
                 'is_pending' => true,
                 'has_warning' => true,
                 'notes' => ['Well-written requirements use RFC 2119 keywords such as MUST, SHOULD, and MAY'],
-            ])
+            ]),
+
+            new RequirementAnalysis([]),
+
+            new RequirementAnalysis([
+                'line'            => 'PARSE ERROR',
+                'has_parse_error' => true,
+            ]),
         ];
         $analysis->rfc2119WarningCount = 1;
         $analysis->customFlagWarningCount = 2;
@@ -372,6 +397,8 @@ class ReporterTest extends TestCase
                     ['', ''],
                     ['-', '  3.a. Funny you should ask'],
                     ['-?', "  3.b. It shood happen to you\nWell-written requirements use RFC 2119 keywords such as MUST, SHOULD, and MAY"],
+                    ['', ''],
+                    ['', 'PARSE ERROR'],
                 ]
             )
             ->once();
@@ -420,8 +447,12 @@ class ReporterTest extends TestCase
      * failure to parse.
      *
      * @LWR 1.g.k. The command should output the number of errors due to gaps.
+     *
+     * @LWR 1.g.g.d.a. The command MUST output parse errors even for 
+     * requirements that do not fall within the super ID supplied to the 
+     * command.
      */
-    public function testReportFewerThings()
+    public function testReportFewerThings_Verbose()
     {
         $analysis = new Analysis();
         $analysis->progress = 60;
@@ -455,7 +486,14 @@ class ReporterTest extends TestCase
                 'is_pending' => true,
                 'has_warning' => true,
                 'notes' => ['Well-written requirements use RFC 2119 keywords such as MUST, SHOULD, and MAY'],
-            ])
+            ]),
+
+            new RequirementAnalysis([]),
+
+            new RequirementAnalysis([
+                'line'            => 'PARSE ERROR',
+                'has_parse_error' => true,
+            ]),
         ];
         $analysis->rfc2119WarningCount = 1;
         $analysis->customFlagWarningCount = 2;
@@ -503,6 +541,8 @@ class ReporterTest extends TestCase
                     ['', '3. The gods must be crazy'],
                     ['-', '  3.a. Funny you should ask'],
                     ['-?', "  3.b. It shood happen to you\nWell-written requirements use RFC 2119 keywords such as MUST, SHOULD, and MAY"],
+                    ['', ''],
+                    ['', 'PARSE ERROR'],
                 ]
             )
             ->once();

--- a/tests/RequirementAnalysisTest.php
+++ b/tests/RequirementAnalysisTest.php
@@ -13,6 +13,7 @@ class RequirementAnalysisTest extends TestCase
         $one = new RequirementAnalysis([]);
         $this->assertEquals('', $one->line);
         $this->assertFalse($one->has_error);
+        $this->assertFalse($one->has_parse_error);
         $this->assertFalse($one->is_obsolete);
         $this->assertFalse($one->is_incomplete);
         $this->assertFalse($one->has_warning);
@@ -20,16 +21,18 @@ class RequirementAnalysisTest extends TestCase
         $this->assertEquals([], $one->notes);
 
         $two = new RequirementAnalysis([
-            'line' => 'ohai',
-            'has_error' => true,
-            'is_obsolete' => true,
-            'is_incomplete' => true,
-            'has_warning' => true,
-            'is_pending' => true,
-            'notes' => ['yeah'],
+            'line'            => 'ohai',
+            'has_error'       => true,
+            'has_parse_error' => true,
+            'is_obsolete'     => true,
+            'is_incomplete'   => true,
+            'has_warning'     => true,
+            'is_pending'      => true,
+            'notes'           => ['yeah'],
         ]);
         $this->assertEquals('ohai', $two->line);
         $this->assertTrue($two->has_error);
+        $this->assertTrue($two->has_parse_error);
         $this->assertTrue($two->is_obsolete);
         $this->assertTrue($two->is_incomplete);
         $this->assertTrue($two->has_warning);

--- a/tests/SpecificationTest.php
+++ b/tests/SpecificationTest.php
@@ -107,11 +107,11 @@ class SpecificationTest extends TestCase
 
         $tree = $specification->getByIdWithChildren(1, true);
 
-        $this->assertCount(6, $tree);
+        $this->assertCount(7, $tree);
 
         $match = array_merge(
             array_slice($set, 0, 5),
-            [$set[8]]
+            ['', $set[8]]
         );
         $this->assertEquals($match, $tree);
     }

--- a/tests/SpecificationTest.php
+++ b/tests/SpecificationTest.php
@@ -58,10 +58,8 @@ class SpecificationTest extends TestCase
     /**
      * @LWR 1.f.a. If an ID was supplied as an argument, the command MAY only 
      * search for that requirement and its sub-requirements.
-     *
-     * In order
      */
-    public function testGetByIdWithChildren()
+    public function testGetByIdWithChildren_ExcludeParseErrors()
     {
         $set = [
             new Requirement('1. Code MUST yield manatees'),
@@ -72,6 +70,7 @@ class SpecificationTest extends TestCase
             '',
             new Requirement('2. Hot Cube'),
             new Requirement('2.a. Not Cube'),
+            new Requirement('2.b Parse error'),
         ];
 
         $specification = new Specification($set);
@@ -80,6 +79,41 @@ class SpecificationTest extends TestCase
 
         $this->assertCount(5, $tree);
         $this->assertEquals(array_slice($set, 0, 5), $tree);
+    }
+
+    /**
+     * @LWR 1.f.a. If an ID was supplied as an argument, the command MAY only 
+     * search for that requirement and its sub-requirements.
+     *
+     * @LWR 1.g.g.d.a. The command MUST output parse errors even for 
+     * requirements that do not fall within the super ID supplied to the 
+     * command.
+     */
+    public function testGetByIdWithChildren_IncludeParseErrors()
+    {
+        $set = [
+            new Requirement('1. Code MUST yield manatees'),
+            new Requirement('1.a. Code MUST yield tees'),
+            '',
+            new Requirement('1.b. Code MUST yield teas'),
+            new Requirement('1.b.a. Code MUST yield manna teas'),
+            '',
+            new Requirement('2. Hot Cube'),
+            new Requirement('2.a. Not Cube'),
+            new Requirement('2.b PARSE ERROR!!!'),
+        ];
+
+        $specification = new Specification($set);
+
+        $tree = $specification->getByIdWithChildren(1, true);
+
+        $this->assertCount(6, $tree);
+
+        $match = array_merge(
+            array_slice($set, 0, 5),
+            [$set[8]]
+        );
+        $this->assertEquals($match, $tree);
     }
 
     /**


### PR DESCRIPTION
There was some trouble with showing requirements with parse errors. They looked like they were addressed because they were absent during an id-based command, because they have no ids.

So now requirements with parse errors are shown in every context.

https://github.com/lower-speck/laravel-lower-speck/issues/4